### PR TITLE
Monoid instance

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,8 +21,9 @@ libraryDependencies += {
 }
 
 libraryDependencies ++= Seq (
-  "org.scalaz"    %% "scalaz-core" % "7.1.0",
-  "org.scalatest" %% "scalatest"   % "2.2.2" % Test
+  "org.scalaz"     %% "scalaz-core" % "7.1.0",
+  "org.spire-math" %% "spire"       % "0.9.0",
+  "org.scalatest"  %% "scalatest"   % "2.2.2" % Test
 )
 
 // wartremoverWarnings ++= Warts.all

--- a/src/main/scala/cosas/ops/typeSets/Conversions.scala
+++ b/src/main/scala/cosas/ops/typeSets/Conversions.scala
@@ -117,14 +117,15 @@ object ParseFrom {
 }
 
 
-trait AnyMonoid {
-  type M
-  def zero: M
-  def append(a: M, b: M): M
-}
+// trait AnyMonoid {
+//   type M
+//   def zero: M
+//   def append(a: M, b: M): M
+// }
 
-trait Monoid[T] extends AnyMonoid { type M = T }
+// trait Monoid[T] extends AnyMonoid { type M = T }
 
+import spire.algebra.Monoid
 
 @annotation.implicitNotFound(msg = "Can't serialize typeset ${S} to ${X}")
 trait SerializeTo[S <: AnyTypeSet, X] extends Fn1[S] with Out[X]
@@ -138,7 +139,7 @@ object SerializeTo {
         (∅ SerializeTo X) = 
     new (∅ SerializeTo X) {
 
-      def apply(r: ∅): Out = m.zero
+      def apply(r: ∅): Out = m.id
     }
 
   implicit def cons[X,
@@ -150,7 +151,7 @@ object SerializeTo {
   ):  ((H :~: T) SerializeTo X) =
   new ((H :~: T) SerializeTo X) {
     
-    def apply(s: H :~: T): Out = m.append(f(s.head), t(s.tail))
+    def apply(s: H :~: T): Out = m.op(f(s.head), t(s.tail))
   }
 
 }

--- a/src/test/scala/cosas/RecordTests.scala
+++ b/src/test/scala/cosas/RecordTests.scala
@@ -230,10 +230,15 @@ class RecordTests extends org.scalatest.FunSuite {
   }
 
   test("serialize") {
+
+    import spire.algebra.Monoid
     // Map //
     implicit def anyMapMonoid[X, Y]: Monoid[Map[X, Y]] = new Monoid[Map[X, Y]] {
-      def zero: M = Map[X, Y]()
-      def append(a: M, b: M): M = a ++ b
+
+      type M = Map[X,Y]
+
+      def id: M = Map[X, Y]()
+      def op(a: M, b: M): M = a ++ b
     }
 
     implicit def serializeProperty[P <: AnyProperty](t: ValueOf[P])
@@ -251,8 +256,11 @@ class RecordTests extends org.scalatest.FunSuite {
 
     // List //
     implicit def anyListMonoid[X]: Monoid[List[X]] = new Monoid[List[X]] {
-      def zero: M = List[X]()
-      def append(a: M, b: M): M = a ++ b
+
+      type M = List[X]
+      
+      def id: M = List[X]()
+      def op(a: M, b: M): M = a ++ b
     }
 
     implicit def propertyIntToStr[P <: AnyProperty](t: ValueOf[P])

--- a/src/test/scala/cosas/TypeSetTests.scala
+++ b/src/test/scala/cosas/TypeSetTests.scala
@@ -351,10 +351,13 @@ class TypeSetTests extends org.scalatest.FunSuite {
 
     val s = name("foo") :~: age(12) :~: key("s0dl52f23k") :~: ∅
 
+    import spire.algebra.Monoid
     // Map //
     implicit def anyMapMonoid[X, Y]: Monoid[Map[X, Y]] = new Monoid[Map[X, Y]] {
-      def zero: M = Map[X, Y]()
-      def append(a: M, b: M): M = a ++ b
+
+      type M = Map[X,Y]
+      def id: M = Map[X, Y]()
+      def op(a: M, b: M): M = a ++ b
     }
 
     implicit def serializeProperty[P <: AnyProperty](t: ValueOf[P])
@@ -371,8 +374,11 @@ class TypeSetTests extends org.scalatest.FunSuite {
 
     // List //
     implicit def anyListMonoid[X]: Monoid[List[X]] = new Monoid[List[X]] {
-      def zero: M = List[X]()
-      def append(a: M, b: M): M = a ++ b
+
+      type M = List[X]
+      
+      def id: M = List[X]()
+      def op(a: M, b: M): M = a ++ b
     }
 
     implicit def propertyToStr[P <: AnyProperty](t: ValueOf[P])


### PR DESCRIPTION
There is a homebrew `Monoid` living in [typeset ops](https://github.com/ohnosequences/cosas/blob/master/src/main/scala/cosas/ops/typeSet/Conversions.scala#L120-L126). We should use scalaz one for this. Do we have scalaz as a dependency in the end?