### PR TITLE
simpler records?

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,5 +21,7 @@ libraryDependencies ++= Seq (
   "org.scalatest"  %% "scalatest" % "2.2.5" % Test
 )
 
+dependencyOverrides += "org.scala-lang.modules" %% "scala-xml" % "1.0.4"
+
 // shows time for each test:
 testOptions in Test += Tests.Argument("-oD")

--- a/src/main/scala/cosas/records.scala
+++ b/src/main/scala/cosas/records.scala
@@ -42,6 +42,8 @@ case object records {
   case object AnyFields {
 
     /* Refiners */
+    type withBound[B <: AnyProperty] = AnyFields { type Properties <: AnyTypeSet.Of[B] }
+
     type withProperties[Ps <: AnyTypeSet.Of[AnyProperty]] = AnyFields { type Properties = Ps }
     type withValues[Vs <: AnyTypeSet] = AnyFields { type Values = Vs }
 

--- a/src/main/scala/cosas/types.scala
+++ b/src/main/scala/cosas/types.scala
@@ -55,7 +55,7 @@ case object types {
 
   /* Denote T with a `value: V`. Normally you write it as `V Denotes T` thus the name. */
   // NOTE: most likely V won't be specialized here
-  final class Denotes[V <: T#Raw, T <: AnyType](val value: V) extends AnyVal with AnyDenotes[V, T] {
+  final class Denotes[V, T <: AnyType](val value: V) extends AnyVal with AnyDenotes[V, T] {
 
     final def show(implicit t: T): String = s"(${t.label} := ${value})"
   }


### PR DESCRIPTION
this could work:

``` scala
package buh

import ohnosequences.cosas._, typeSets._, types._, properties._

trait AnyRecord extends AnyType {

  type Properties <: AnyTypeSet
  type Raw <: AnyTypeSet
}


case object nrec extends AnyRecord {

  type Properties = ∅
  type Raw = ∅

  val label = "emtpy record"
}
case class :>:[P <: AnyProperty, R <: AnyRecord](val head: P, val tail: R) extends AnyRecord {

  type Properties = P :~: R#Properties
  type Raw = ValueOf[P] :~: R#Raw

  val label = s"${head.label} + ${tail.label}"
}

class Rec[R <: AnyRecord](val r: R)

object doSomething {
  type nrec = nrec.type
  case object a extends Property[String]("a"); type a = a.type
  case object b extends Property[Int]("b"); type b = b.type

  object ab extends :>:(a, :>:(b, nrec))

  val abAgain = :>:(a, :>:(b, nrec))

  val zz: ValueOf[ab.type] = ab := (a("aaaa") :~: b(2) :~: ∅)

  val z: ValueOf[:>:[a, :>:[b, nrec]]] = abAgain := zz.value
}
```