### PR TITLE
better serialization

### DIFF
--- a/src/main/scala/cosas/ops/records/Conversions.scala
+++ b/src/main/scala/cosas/ops/records/Conversions.scala
@@ -7,7 +7,7 @@ import ops.typeSets._
   Cannot parse fields
     ${PS}
   from a Map[String, ${V}].
-  Probably you haven't provided property parsers for all properties involved.
+  Probably you haven't provided property parsers for all properties in ${PS}.
 """)
 trait ParsePropertiesFrom[PS <: AnyPropertySet, V] extends Fn1[Map[String,V]]
   with Out[ Either[AnyPropertyParsingError, PS#Raw] ]
@@ -53,6 +53,12 @@ object ParsePropertiesFrom {
   }
 }
 
+@annotation.implicitNotFound(msg = """
+  Cannot serialize fields
+    ${PS}
+  to a Map[String, ${V}].
+  Probably you haven't provided property serializers for all properties in ${PS}.
+""")
 trait SerializePropertiesTo[PS <: AnyPropertySet, V] extends Fn2[Map[String,V], PS#Raw]
   with Out[ Either[AnyPropertySerializationError, Map[String,V]] ]
 

--- a/src/main/scala/cosas/ops/records/Conversions.scala
+++ b/src/main/scala/cosas/ops/records/Conversions.scala
@@ -52,3 +52,47 @@ object ParsePropertiesFrom {
     }
   }
 }
+
+trait SerializePropertiesTo[PS <: AnyPropertySet, V] extends Fn2[Map[String,V], PS#Raw]
+  with Out[ Either[AnyPropertySerializationError, Map[String,V]] ]
+
+  object SerializePropertiesTo {
+
+    def apply[F <: AnyPropertySet, V]
+      (implicit serializer: SerializePropertiesTo[F, V]): SerializePropertiesTo[F, V] = serializer
+
+    implicit def empty[V]:
+          (□ SerializePropertiesTo V) =
+      new (□ SerializePropertiesTo V) {
+
+        def apply(map: Map[String,V], t: ∅): Out = Right(map)
+      }
+
+    implicit def cons[
+      V,
+      H <: AnyProperty, T <: AnyPropertySet,
+      PH <: AnyPropertySerializer { type Property = H; type Value = V }
+    ](implicit
+      serializeP: PH,
+      serializeT: SerializePropertiesTo[T, V]
+    ):  ( (H :&: T) SerializePropertiesTo V ) =
+    new ( (H :&: T) SerializePropertiesTo V ) {
+
+      def apply(map: Map[String,V], pvs: ValueOf[H] :~: T#Raw): Out = {
+
+        val errOrMap = serializeP.serialize(map, pvs.head.value)
+
+        errOrMap match {
+
+          case Left(err) => Left(err)
+
+          case Right(map) => serializeT(map, pvs.tail) match {
+
+            case Left(err) => Left(err)
+
+            case Right(fmap) => Right(fmap)
+          }
+        }
+      }
+    }
+  }

--- a/src/main/scala/cosas/ops/records/Conversions.scala
+++ b/src/main/scala/cosas/ops/records/Conversions.scala
@@ -4,10 +4,14 @@ import ohnosequences.cosas._, fns._, types._, typeSets._, records._, properties.
 import ops.typeSets._
 
 @annotation.implicitNotFound(msg = """
-  Cannot parse fields
+  Cannot parse fields:
+
     ${PS}
+
   from a Map[String, ${V}].
-  Probably you haven't provided property parsers for all properties in ${PS}.
+  Probably you haven't provided property parsers for all properties in
+
+    ${PS}
 """)
 trait ParsePropertiesFrom[PS <: AnyPropertySet, V] extends Fn1[Map[String,V]]
   with Out[ Either[AnyPropertyParsingError, PS#Raw] ]
@@ -54,10 +58,14 @@ object ParsePropertiesFrom {
 }
 
 @annotation.implicitNotFound(msg = """
-  Cannot serialize fields
+  Cannot serialize fields:
+
     ${PS}
+
   to a Map[String, ${V}].
-  Probably you haven't provided property serializers for all properties in ${PS}.
+  Probably you haven't provided property serializers for all properties in:
+
+    ${PS}
 """)
 trait SerializePropertiesTo[PS <: AnyPropertySet, V] extends Fn2[Map[String,V], PS#Raw]
   with Out[ Either[AnyPropertySerializationError, Map[String,V]] ]

--- a/src/main/scala/cosas/properties.scala
+++ b/src/main/scala/cosas/properties.scala
@@ -16,6 +16,64 @@ object properties {
     implicit def propertyOps[P <: AnyProperty](p: P): PropertyOps[P] = PropertyOps(p)
   }
 
+  trait AnyPropertySerializer { serializer =>
+
+    type Property <: AnyProperty
+    val property: Property
+
+    type Value
+    type To = Map[String, Value]
+
+    val propertyValueSerializer: Property#Raw => Option[Value]
+
+    val keyRep: String
+
+    val serialize: (To, Property#Raw) => Either[AnyPropertySerializationError, To] =
+      (map, value) => map get keyRep match {
+
+        case Some(v) => Left(KeyPresent(property, keyRep))
+
+        case None => propertyValueSerializer(value) match {
+
+          case None => Left(ErrorSerializingValue(property, property(value)))
+
+          case Some(pv) => Right(map + (keyRep -> pv) )
+        }
+      }
+  }
+
+  case class PropertySerializer[P <: AnyProperty,V](
+    val property: P,
+    val keyRep: String)(
+    val propertyValueSerializer: P#Raw => Option[V]
+  ) extends AnyPropertySerializer {
+
+    type Property = P
+    type Value = V
+  }
+
+
+
+  sealed trait AnyPropertySerializationError {
+
+    type Property <: AnyProperty
+    type Value
+    type To = Map[String, Value]
+  }
+  case class KeyPresent[P <: AnyProperty, Vl](val p: P, val keyRep: String)
+  extends AnyPropertySerializationError {
+
+    type Property = P
+    type Value = Vl
+  }
+
+  case class ErrorSerializingValue[P <: AnyProperty, Vl](val p: P, val value: ValueOf[P])
+  extends AnyPropertySerializationError {
+
+    type Property = P
+    type Value = Vl
+  }
+
   trait AnyPropertyParser { parser =>
 
     type Property <: AnyProperty

--- a/src/main/scala/cosas/properties.scala
+++ b/src/main/scala/cosas/properties.scala
@@ -101,7 +101,7 @@ object properties {
   }
   case class PropertyParser[P <: AnyProperty,V](
     val property: P,
-    val keyRep: String,
+    val keyRep: String)(
     val propertyValueParser: V => Option[P#Raw]
   ) extends AnyPropertyParser {
 

--- a/src/main/scala/cosas/records.scala
+++ b/src/main/scala/cosas/records.scala
@@ -73,6 +73,10 @@ case object records {
     RecordEntryOps(entry.value)
   case class RecordEntryOps[RT <: AnyRecord](val entryRaw: RT#Raw) extends AnyVal {
 
+    def serializeTo[V](implicit
+      serialize: RT#PropertySet SerializePropertiesTo V
+    ): Either[AnyPropertySerializationError, Map[String,V]] = serialize(Map(), entryRaw)
+
     def get[P <: AnyProperty](p: P)(implicit
       get: RT Get P
     ): ValueOf[P] = p := get(entryRaw)

--- a/src/main/scala/cosas/records.scala
+++ b/src/main/scala/cosas/records.scala
@@ -77,6 +77,11 @@ case object records {
       serialize: RT#PropertySet SerializePropertiesTo V
     ): Either[AnyPropertySerializationError, Map[String,V]] = serialize(Map(), entryRaw)
 
+    def serializeTo[V](map: Map[String,V])(implicit
+      serialize: RT#PropertySet SerializePropertiesTo V
+    ): Either[AnyPropertySerializationError, Map[String,V]] = serialize(map, entryRaw)
+
+
     def get[P <: AnyProperty](p: P)(implicit
       get: RT Get P
     ): ValueOf[P] = p := get(entryRaw)

--- a/src/test/scala/cosas/RecordTests.scala
+++ b/src/test/scala/cosas/RecordTests.scala
@@ -168,9 +168,12 @@ class RecordTests extends org.scalatest.FunSuite {
       "id" -> "twenty-two"
     )
 
+    val mapWithOtherStuff = simpleUserEntryMap + ("other" -> "stuff")
+
     assert { ( simpleUser parseFrom simpleUserEntryMap ) === Right(simpleUser(id(29681) :~: name("Antonio") :~: ∅)) }
     assert { ( simpleUser parseFrom wrongKeyMap ) === Left(KeyNotFound(id)) }
     assert { ( simpleUser parseFrom notIntValueMap ) === Left(ErrorParsingValue(id,"twenty-two")) }
+    assert { ( simpleUser parseFrom mapWithOtherStuff ) === Right(simpleUser(id(29681) :~: name("Antonio") :~: ∅)) }
   }
 
   test("can serialize records to Maps") {
@@ -182,5 +185,19 @@ class RecordTests extends org.scalatest.FunSuite {
       "name" -> "Antonio"
     )
     assert { Right(simpleUserEntryMap) === simpleUser(id(29681) :~: name("Antonio") :~: ∅).serializeTo[String] }
+
+    val unrelatedMap = Map(
+      "lala" -> "hola!",
+      "ohno" -> "pigeons"
+    )
+
+    val mapWithKey = unrelatedMap + ("id" -> "1321")
+
+    assert {
+      Right(simpleUserEntryMap ++ unrelatedMap) ===
+        ( simpleUser(id(29681) :~: name("Antonio") :~: ∅) serializeTo unrelatedMap )
+    }
+
+    assert { Left(KeyPresent(id, id.label)) === ( simpleUser(id(29681) :~: name("Antonio") :~: ∅) serializeTo mapWithKey ) }
   }
 }

--- a/src/test/scala/cosas/RecordTests.scala
+++ b/src/test/scala/cosas/RecordTests.scala
@@ -144,7 +144,6 @@ class RecordTests extends org.scalatest.FunSuite {
         catching(classOf[NumberFormatException]) opt str.toInt
       }
     implicit val idParser = PropertyParser[id.type, String](id, id.label, idVParser)
-
     implicit val nameParser = PropertyParser[name.type, String](name, name.label, { str: String => Some(str) } )
 
     val simpleUserEntryMap =  Map(
@@ -164,5 +163,18 @@ class RecordTests extends org.scalatest.FunSuite {
     assert { ( simpleUser parseFrom simpleUserEntryMap ) === Right(simpleUser(id(29681) :~: name("Antonio") :~: ∅)) }
     assert { ( simpleUser parseFrom wrongKeyMap ) === Left(KeyNotFound(id)) }
     assert { ( simpleUser parseFrom notIntValueMap ) === Left(ErrorParsingValue(id,"twenty-two")) }
+  }
+
+  test("can serialize records to Maps") {
+
+    implicit val idSerializer   = PropertySerializer(id, id.label)({ x => Some(x.toString) })
+    implicit val nameSerializer = PropertySerializer(name, name.label)({ x => Some(x) })
+
+    val simpleUserEntryMap =  Map(
+      "id" -> "29681",
+      "name" -> "Antonio"
+    )
+
+    assert { Right(simpleUserEntryMap) === simpleUser(id(29681) :~: name("Antonio") :~: ∅).serializeTo[String] }
   }
 }


### PR DESCRIPTION
Same as in #45, we need record serialization to `Map[String,V]` with a couple of possible errors:

- Key already there
- error serializing value to `V`