### PR TITLE
TakeFirst for KLists

### DIFF
--- a/src/main/scala/cosas/klists/package.scala
+++ b/src/main/scala/cosas/klists/package.scala
@@ -35,4 +35,7 @@ package object klists {
 
   type  replace[L <: AnyKList] = Replace[L]
   def   replace[L <: AnyKList]: replace[L] = new Replace[L]
+
+  type  takeFirst[Q <: AnyKList] = TakeFirst[Q]
+  def   takeFirst[Q <: AnyKList]: takeFirst[Q] = new TakeFirst[Q]
 }

--- a/src/main/scala/cosas/klists/syntax.scala
+++ b/src/main/scala/cosas/klists/syntax.scala
@@ -47,10 +47,17 @@ case object syntax {
     : (E,O) =
       p(l)
 
+    def takeFirst[Q <: KList.Of[L#Bound]](w: Witness[Q])(implicit
+      takeFirst: App1[takeFirst[Q], L, Q]
+    )
+    : Q =
+      takeFirst(l)
+
     def replaceFirst[S <: AnyKList { type Bound = L#Bound }](s: S)(implicit
       replaceFirst: App2[replace[L], L, S, L]
     )
-    : L = replaceFirst(l,s)
+    : L =
+      replaceFirst(l,s)
 
     def toList(implicit conv: App1[toList[L], L, List[L#Bound]])
     : List[L#Bound] =

--- a/src/main/scala/cosas/klists/takeFirst.scala
+++ b/src/main/scala/cosas/klists/takeFirst.scala
@@ -1,0 +1,22 @@
+package ohnosequences.cosas.klists
+
+import ohnosequences.cosas._, fns._, klists._
+
+class TakeFirst[Q <: AnyKList] extends DepFn1[AnyKList, Q]
+
+case object TakeFirst {
+
+  implicit def empty[S <: AnyKList { type Bound = X }, X]
+  : App1[TakeFirst[*[X]], S, *[X]] =
+    App1 { s: S => *[X] }
+
+  implicit def nonEmpty[
+    TailToTake <: AnyKList, From <: AnyKList, Rest <: AnyKList,
+    HeadToTake <: TailToTake#Bound
+  ](implicit
+    pick: App1[pick[HeadToTake], From, (HeadToTake, Rest)],
+    take: App1[TakeFirst[TailToTake], Rest, TailToTake]
+  )
+  : App1[TakeFirst[HeadToTake :: TailToTake], From, HeadToTake :: TailToTake] =
+    App1 { s: From => { val (h, t) = pick(s); h :: take(t) } }
+}

--- a/src/test/scala/cosas/KListsTests.scala
+++ b/src/test/scala/cosas/KListsTests.scala
@@ -178,6 +178,13 @@ class KListTests extends org.scalatest.FunSuite {
     assert { (z replaceFirst "hola" :: *[Any]) === "hola" :: z.tail }
   }
 
+  test("can take a sublist by type") {
+
+      val z = "a" :: 'b' :: true :: 2 :: "cd" :: false :: *[Any]
+
+      assert { (z takeFirst /[Boolean :: Int :: *[Any]]) === true :: 2 :: *[Any] }
+  }
+
   test("can map over KLists") {
 
     case object f extends DepFn1[Any,String] {


### PR DESCRIPTION
This should take a Klist `l` and a witness for a KList type `S` and take the first sublist of `l` conforming to `S`.