### PR TITLE
Product type's unit

### DIFF
--- a/src/main/scala/cosas/records/package.scala
+++ b/src/main/scala/cosas/records/package.scala
@@ -4,7 +4,7 @@ import ohnosequences.cosas._, types._, klists._
 
 package object records {
 
-  type EmptyRecordType = AnyRecordType.withKeys[unit]
+  type EmptyRecordType = AnyRecordType.withKeys[|[AnyType]]
 
   implicit def recordReorderSyntax[Vs <: AnyKList.withBound[AnyDenotation]](vs: Vs)
   : syntax.RecordReorderSyntax[Vs] =

--- a/src/main/scala/cosas/records/reorder.scala
+++ b/src/main/scala/cosas/records/reorder.scala
@@ -10,7 +10,7 @@ class Reorder[Ts <: AnyProductType, Vs <: AnyKList { type Bound = AnyDenotation 
 case object Reorder {
 
   implicit def empty[S <: AnyKList { type Bound = AnyDenotation }]
-  : AnyApp1At[Reorder[unit, S], S] { type Y = *[AnyDenotation] } =
+  : AnyApp1At[Reorder[|[AnyType], S], S] { type Y = *[AnyDenotation] } =
     App1 { s: S => *[AnyDenotation] }
 
   implicit def nonEmpty[

--- a/src/main/scala/cosas/types/package.scala
+++ b/src/main/scala/cosas/types/package.scala
@@ -4,9 +4,6 @@ package object types {
 
   type :=[T <: AnyType, +V <: T#Raw] = Denotes[V,T]
 
-  type unit = EmptyProductType[AnyType]
-  val  unit : unit = new EmptyProductType[AnyType]
-
-  type In[E <: AnyType] = EmptyProductType[E]
-  def In[E <: AnyType]: In[E] = new EmptyProductType[E]
+  type |[E <: AnyType] = EmptyProductType[E]
+  def  |[E <: AnyType]: |[E] = new EmptyProductType[E]
 }

--- a/src/main/scala/cosas/types/parsing.scala
+++ b/src/main/scala/cosas/types/parsing.scala
@@ -64,11 +64,11 @@ class ParseDenotations[V, Ts <: AnyProductType] extends DepFn1[Map[String,V], Ei
 case object ParseDenotations {
 
   implicit def empty[V,X]
-  : AnyApp1At[ParseDenotations[V,unit], Map[String,V]] { type Y =  Either[ParseDenotationsError,*[AnyDenotation]] } =
+  : AnyApp1At[ParseDenotations[V, |[AnyType]], Map[String,V]] { type Y =  Either[ParseDenotationsError,*[AnyDenotation]] } =
     App1 { map: Map[String,V] => Right(*[AnyDenotation]) }
 
   implicit def emptyParam[V, T <: AnyType, X]
-  : AnyApp1At[ParseDenotations[V,In[T]], Map[String,V]] { type Y =  Either[ParseDenotationsError,*[AnyDenotation]] } =
+  : AnyApp1At[ParseDenotations[V, |[T]], Map[String,V]] { type Y =  Either[ParseDenotationsError,*[AnyDenotation]] } =
     App1 { map: Map[String,V] => Right(*[AnyDenotation]) }
 
   implicit def nonEmpty[

--- a/src/test/scala/cosas/DenotationTests.scala
+++ b/src/test/scala/cosas/DenotationTests.scala
@@ -16,7 +16,7 @@ case object DenotationTestsContext {
 
   val FavoriteColor = (User ==> Color)
 
-  val colorAndFriend = Color :×: Friend :×: unit
+  val colorAndFriend = Color :×: Friend :×: |[AnyType]
 
   sealed trait Colors extends AnyType { type Raw = Any; lazy val label: String = toString }
   case object Blue    extends Colors
@@ -145,7 +145,7 @@ class DenotationTests extends org.scalatest.FunSuite {
     assert { (zz getFirst Friend) === (zz at _1) }
 
     // NOTE a bounded product type
-    val FranceFlag = Blue :×: White :×: Red :×: In[Colors]
+    val FranceFlag = Blue :×: White :×: Red :×: |[Colors]
 
     val viveLaFrance = FranceFlag :=  (Blue := "Vive")    ::
                                       (White := "la")     ::

--- a/src/test/scala/cosas/RecordTests.scala
+++ b/src/test/scala/cosas/RecordTests.scala
@@ -10,10 +10,10 @@ case object recordTestsContext {
   case object email extends Type[String]("email")
   case object color extends Type[String]("color")
 
-  case object simpleUser extends RecordType(id :×: name :×: unit)
-  case object normalUser extends RecordType(id :×: name :×: email :×: color :×: unit)
+  case object simpleUser extends RecordType(id :×: name :×: |[AnyType])
+  case object normalUser extends RecordType(id :×: name :×: email :×: color :×: |[AnyType])
 
-  val volatileRec = new RecordType(email :×: color :×: unit)
+  val volatileRec = new RecordType(email :×: color :×: |[AnyType])
 
   val volatileRecEntry = volatileRec (
     email("oh@buh.com") ::


### PR DESCRIPTION
I suggest to make `unit` thing always parametric (i.e. what is called now `In`): [here](https://github.com/ohnosequences/cosas/blob/master/src/main/scala/cosas/types/package.scala#L7-L11). Just to make it more uniform.