### PR TITLE
predicates are wrong; they are fixable though

### DIFF
--- a/src/main/scala/cosas/Nat.scala
+++ b/src/main/scala/cosas/Nat.scala
@@ -23,9 +23,9 @@ trait AnyNonZeroNat extends AnyNat { nz =>
 
   type Next <: AnyNonZeroNat
   type Pred <: AnyNat
-  val pred: Pred
+  val  pred: Pred
 
-  type StrictlySmaller = Pred#StrictlySmaller or Pred
+  type StrictlySmaller = Pred#StrictlySmaller#or[Pred]
 }
 
 case class Successor[N <: AnyNat](val pred: N) extends AnyNonZeroNat {

--- a/src/main/scala/cosas/fns/predicates.scala
+++ b/src/main/scala/cosas/fns/predicates.scala
@@ -40,10 +40,10 @@ trait AnyAnd extends AnyPredicate { and =>
   type First <: AnyPredicate
   val first: First
 
-  type Second <: AnyPredicate { type In1 = and.First#In1 }
+  type Second <: AnyPredicate { type In1 = and.In1 }
   val second: Second
 }
-case class and[
+case class And[
   P1 <: AnyPredicate,
   P2 <: AnyPredicate { type In1 = P1#In1 }
 ](val first: P1, val second: P2) extends AnyAnd {
@@ -64,14 +64,14 @@ case object AnyAnd {
     App1 { x: V => () }
 }
 
-trait AnyOr extends AnyPredicate { and =>
+trait AnyOr extends AnyPredicate { or =>
 
   type In1 = First#In1
 
   type First <: AnyPredicate
   val first: First
 
-  type Second <: AnyPredicate { type In1 = and.First#In1 }
+  type Second <: AnyPredicate { type In1 = or.In1 }
   val second: Second
 }
 case class Or[
@@ -94,7 +94,7 @@ case object AnyOr {
     App1 { x: V => () }
 
   implicit def secondTrue[
-    AP <: AnyOr { type Second <: AnyPredicate {  type In1 >: V } },
+    AP <: AnyOr { type Second <: AnyPredicate { type In1 >: V } },
     V <: AP#In1
   ](implicit
     p1: AP#Second isTrueOn V

--- a/src/main/scala/cosas/fns/syntax.scala
+++ b/src/main/scala/cosas/fns/syntax.scala
@@ -22,10 +22,8 @@ case object syntax {
 
     // for constructing evidences
     def isTrueOn[X <: P#In1]:  P isTrueOn X  = App1 { _: X => () }
-    // def isFalseOn[X <: P#In1]: P isFalseOn X = App1 { _: X => False }
 
-    def ∧[O <: AnyPredicate { type In1 = P#In1 }](o: O): P and O = and(p,o)
-
+    def ∧[O <: AnyPredicate { type In1 = P#In1 }](o: O): P And O = And(p,o)
     def ∨[O <: AnyPredicate { type In1 = P#In1 }](o: O): P Or O = Or(p,o)
   }
 

--- a/src/main/scala/cosas/typeUnions/package.scala
+++ b/src/main/scala/cosas/typeUnions/package.scala
@@ -7,8 +7,6 @@ package object typeUnions {
   private[cosas] type just[+T] = not[not[T]]
   type empty = either[Nothing]
 
-  type or[T <: AnyTypeUnion, S] = T#or[S]
-
   @annotation.implicitNotFound(msg = "Can't prove that ${X} is one of ${U}")
   type    isOneOf[X, U <: AnyTypeUnion] = just[X] ≤  U#union
 

--- a/src/test/scala/cosas/KListsTests.scala
+++ b/src/test/scala/cosas/KListsTests.scala
@@ -411,6 +411,11 @@ class KListTests extends org.scalatest.FunSuite {
       ('b' :: true :: "hola" :: 2 :: 'a' :: *[Any]).filter(isAnyVal ∨ isString)
     }
 
+    // this is to check that ∨ is not ambiguous:
+    assertResult('b' :: true :: 2 :: 'a' :: *[Any]) {
+      ('b' :: true :: "hola" :: 2 :: 'a' :: *[Any]).filter(isInt ∨ isAnyVal)
+    }
+
     assertResult(2 :: *[Any]) {
       ('b' :: Set("a") :: true :: "hola" :: List(1,2,3) :: 2 :: 'a' :: *[Any]).filter(isAnyVal ∧ isInt)
     }

--- a/src/test/scala/cosas/TypeUnionTests.scala
+++ b/src/test/scala/cosas/TypeUnionTests.scala
@@ -8,12 +8,12 @@ class TypeUnionTests extends org.scalatest.FunSuite {
   test("check bounds") {
 
     type S      = either[String]
-    type SB     = either[String] or Boolean
-    type SB2    = either[String] or Boolean
-    type SBI    = either[String] or Boolean or Int
+    type SB     = either[String]#or[Boolean]
+    type SB2    = either[String]#or[Boolean]
+    type SBI    = either[String]#or[Boolean]#or[Int]
     trait Bar
-    type BarBIS = either[String] or Int or Boolean or Bar
-    type Uh     = either[Byte] or Int or Boolean or String
+    type BarBIS = either[String]#or[Int]#or[Boolean]#or[Bar]
+    type Uh     = either[Byte]#or[Int]#or[Boolean]#or[String]
 
     implicitly[just[String] ≤ Uh#union]
     implicitly[ sub.type isTrueOn (just[String], Uh#union) ]
@@ -51,14 +51,14 @@ class TypeUnionTests extends org.scalatest.FunSuite {
     trait Dog extends Animal
 
     // everyone fits here
-    type DCA = either[Dog] or Cat or Animal
+    type DCA = either[Dog]#or[Cat]#or[Animal]
     implicitly[Dog isOneOf DCA]
     implicitly[Cat isOneOf DCA]
     implicitly[UglyCat isOneOf DCA]
     implicitly[pipo.type isOneOf DCA]
     implicitly[uglyCat.type isOneOf DCA]
 
-    type DC = either[Dog] or Cat
+    type DC = either[Dog]#or[Cat]
     implicitly[Dog isOneOf DC]
     implicitly[Cat isOneOf DC]
     implicitly[UglyCat isOneOf DC]
@@ -67,7 +67,7 @@ class TypeUnionTests extends org.scalatest.FunSuite {
     // not here
     implicitly[animal.type isNotOneOf DC]
 
-    type DUC = either[Dog] or UglyCat
+    type DUC = either[Dog]#or[UglyCat]
     implicitly[Dog isOneOf DUC]
     implicitly[UglyCat isOneOf DUC]
     implicitly[pipo.type isOneOf DUC]
@@ -76,8 +76,8 @@ class TypeUnionTests extends org.scalatest.FunSuite {
     implicitly[Cat isNotOneOf DUC]
     implicitly[animal.type isNotOneOf DUC]
 
-    type ISDUC = either[String] or Int or Dog or UglyCat
-    type DUCIS = either[Dog] or UglyCat or String or Int
+    type ISDUC = either[String]#or[Int]#or[Dog]#or[UglyCat]
+    type DUCIS = either[Dog]#or[UglyCat]#or[String]#or[Int]
     implicitly[Dog isOneOf ISDUC]
     implicitly[UglyCat isOneOf ISDUC]
     implicitly[pipo.type isOneOf ISDUC]


### PR DESCRIPTION
- [x] Predicate should be fn1 with out Unit
- [x] and/or OK; not impossible
- [ ] need to resort to ambiguity for cases like not subtype of