### PR TITLE
Bug in AnyKList.fromList

### DIFF
--- a/src/main/scala/cosas/klists/klists.scala
+++ b/src/main/scala/cosas/klists/klists.scala
@@ -64,16 +64,16 @@ case object AnyKList {
   : syntax.KListSyntax[L] =
     syntax.KListSyntax[L](l)
 
-    def fromList[X](l: List[X]): AnyKList { type Bound = X } = fromList_rec(l,*[X])
+  def fromList[X](l: List[X]): AnyKList { type Bound = X } =
+    fromList_rec(l.reverse, *[X])
 
-    @scala.annotation.tailrec
-    private def fromList_rec[X](
-      list: List[X],
-      acc: AnyKList.withBound[X]
-    )
-    : AnyKList.withBound[X] = list.reverse match {
-      case x :: xs  => fromList_rec[X](xs, x :: acc)
-      case Nil      => acc
-    }
+  @scala.annotation.tailrec
+  private def fromList_rec[X](
+    reversedList: List[X],
+    acc: AnyKList.withBound[X]
+  ): AnyKList.withBound[X] = reversedList match {
+    case x :: xs  => fromList_rec[X](xs, x :: acc)
+    case Nil      => acc
+  }
 
 }

--- a/src/test/scala/cosas/KListsTests.scala
+++ b/src/test/scala/cosas/KListsTests.scala
@@ -9,6 +9,7 @@ case object KListTestsContext {
 
   case object A0 extends A { val boo = true }
   case object A1 extends A { val boo = false }
+  case object A2 extends A { val boo = true }
 
 }
 
@@ -60,6 +61,27 @@ class KListTests extends org.scalatest.FunSuite {
     def foo[L <: AnyNonEmptyKList.Of[A]](l: L): Boolean = l.head.boo
 
     assert{ foo(oh) === true }
+  }
+
+  test("can convert normal Lists to KLists and back") {
+
+    val as = A0 :: A1 :: A2 :: Nil
+    val aks = (A0 :: A1 :: A2 :: *[A])
+
+    // list -> klist
+    assert { AnyKList.fromList(as) === aks }
+
+    // list -> klist -> list
+    assert { AnyKList.fromList(as).asList === as }
+
+    // klist -> list -> klist
+    assert { AnyKList.fromList(aks.asList) === aks }
+
+    // ensuring correct order:
+    assert {
+      AnyKList.fromList(1 :: 2 :: 3 :: 4 :: Nil) ===
+      (1 :: 2 :: 3 :: 4 :: *[Int])
+    }
   }
 
   test("can convert KLists to lists of their bound") {


### PR DESCRIPTION
Noticed this by accident: `AnyKList.fromList` mixes up the order of elements, because it reverses list on every recursion iteration. I guess we never used this so this bug stayed unnoticed. Anyway, I fixed it and added some tests.